### PR TITLE
Update Octopus.Features.WindowsService_BeforePostDeploy.ps1

### DIFF
--- a/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
+++ b/source/Calamari/Scripts/Octopus.Features.WindowsService_BeforePostDeploy.ps1
@@ -177,8 +177,7 @@ if ($description)
 	}
 }
 
-$wmiServiceName = $serviceName -replace "'", "\'"
-$status = Get-WMIObject win32_service -filter ("name='" + $wmiServiceName + "'") -computer "." | select -expand startMode
+$status = Get-Service -Name $serviceName | select -expand starttype
 
 if ($startMode -eq "unchanged")
 {


### PR DESCRIPTION
- Fixed WMI service deployment delay issue. 

This script used WMI to check the current service status. On one of our machines this caused the deployment step to tak 15 minutes or more. Therefor I replaced the WMI with a standard PS equivalent command. Field testing shows this works as expected. The 15 minute delay has gone.